### PR TITLE
Prevent derived classes without attributes from being registered based on their base class attributes

### DIFF
--- a/src/Extensions/ContainerBuilderExtensions.cs
+++ b/src/Extensions/ContainerBuilderExtensions.cs
@@ -16,7 +16,7 @@ namespace Autofac.AttributeExtensions
 
             foreach (Type type in attributedTypes)
             {
-                IEnumerable<RegistrationAttribute> registrationAttributes = type.GetCustomAttributes<RegistrationAttribute>();
+                IEnumerable<RegistrationAttribute> registrationAttributes = type.GetCustomAttributes<RegistrationAttribute>(false);
 
                 foreach (RegistrationAttribute attribute in registrationAttributes)
                 {

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Autofac.AttributeExtensions;
 using Autofac.Core;
 using Autofac.Core.Lifetime;
@@ -44,6 +47,20 @@ namespace Autofac.Attributes.Tests
 
             result1.ShouldBe(result2)
                 .And.ShouldBe(result3);
+        }
+
+        [Fact]
+        public void DerivedClass_BaseClassHasAttribute_IsNotRegistered()
+        {
+            _sut.IsRegistered<DerivedClassWithoutAttribute>().ShouldBe(false);
+        }
+
+        [Fact]
+        public void DerivedClassWithAttribute_BaseClassHasAttribute_IsRegistered()
+        {
+            _sut.IsRegistered<DerivedClassWithAttribute>().ShouldBe(true);
+            _sut.Resolve<IEnumerable<IInterface>>()
+                .Select(t => t.GetType()).ShouldMatch(typeof(DerivedClassWithAttribute), typeof(ImplementsInterface));
         }
 
         [Fact]
@@ -174,6 +191,9 @@ namespace Autofac.Attributes.Tests
 
     [SingleInstance]
     class ImplementsInterface : BaseClass, IInterface { }
+    class DerivedClassWithoutAttribute : ImplementsInterface { }
+    [SingleInstance]
+    class DerivedClassWithAttribute : ImplementsInterface { }
 
     interface IUnregistered { }
 

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -59,8 +59,8 @@ namespace Autofac.Attributes.Tests
         public void DerivedClassWithAttribute_BaseClassHasAttribute_IsRegistered()
         {
             _sut.IsRegistered<DerivedClassWithAttribute>().ShouldBe(true);
-            _sut.Resolve<IEnumerable<IInterface>>()
-                .Select(t => t.GetType()).ShouldMatch(typeof(DerivedClassWithAttribute), typeof(ImplementsInterface));
+            _sut.Resolve<IEnumerable<IBaseClassWithAttribute>>()
+                .Select(t => t.GetType()).ShouldMatch(typeof(DerivedClassWithAttribute), typeof(BaseClassWithAttribute));
         }
 
         [Fact]
@@ -191,9 +191,13 @@ namespace Autofac.Attributes.Tests
 
     [SingleInstance]
     class ImplementsInterface : BaseClass, IInterface { }
-    class DerivedClassWithoutAttribute : ImplementsInterface { }
+
+    interface IBaseClassWithAttribute { }
     [SingleInstance]
-    class DerivedClassWithAttribute : ImplementsInterface { }
+    class BaseClassWithAttribute: IBaseClassWithAttribute { }
+    class DerivedClassWithoutAttribute : BaseClassWithAttribute { }
+    [SingleInstance]
+    class DerivedClassWithAttribute : BaseClassWithAttribute { }
 
     interface IUnregistered { }
 


### PR DESCRIPTION
Prevent derived classes without attributes from being registered based on their base class attributes.
This can be confusing behaviour as the derived class shouldn't implicitly be registered and share the same lifetimes as the parent.